### PR TITLE
fix(logging): remove duplicate banner, add colors and cleaner format

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import sys
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -182,18 +183,22 @@ def _run_alembic_stamp_head():
     )
 
 
+_BANNER = (
+    "\n"
+    "  " + "─" * 54 + "\n"
+    r"        _             _ _                       _ _" + "\n"
+    r"       / \  _   _  __| (_) _____   ____ _ _   _| | |_" + "\n"
+    r"      / _ \| | | |/ _` | |/ _ \ \ / / _` | | | | | __|" + "\n"
+    r"     / ___ \ |_| | (_| | | (_) \ V / (_| | |_| | | |_" + "\n"
+    r"    /_/   \_\__,_|\__,_|_|\___/ \_/ \__,_|\__,_|_|\__|" + "\n"
+    "  " + "─" * 54 + "\n"
+)
+
+
 @application.on_event("startup")
 async def startup_event():
-    banner = r"""
-        _             _ _                       _ _
-       / \  _   _  __| (_) _____   ____ _ _   _| | |_
-      / _ \| | | |/ _` | |/ _ \ \ / / _` | | | | | __|
-     / ___ \ |_| | (_| | | (_) \ V / (_| | |_| | | |_
-    /_/   \_\__,_|\__,_|_|\___/ \_/ \__,_|\__,_|_|\__|
-
-    """
-    logger.info(banner)
-    print(banner)  # Ensure it prints to console even if logs are diverted
+    sys.stdout.write(_BANNER)
+    sys.stdout.flush()
 
     # Database setup with retry logic
     retries = 5

--- a/backend/app/utils/logger.py
+++ b/backend/app/utils/logger.py
@@ -9,11 +9,11 @@ from app.core.config import settings
 _RESET = "\033[0m"
 _BOLD = "\033[1m"
 _LEVEL_COLORS = {
-    logging.DEBUG: "\033[36m",     # cyan
-    logging.INFO: "\033[32m",      # green
-    logging.WARNING: "\033[33m",   # yellow
-    logging.ERROR: "\033[31m",     # red
-    logging.CRITICAL: "\033[1;31m", # bold red
+    logging.DEBUG: "\033[36m",  # cyan
+    logging.INFO: "\033[32m",  # green
+    logging.WARNING: "\033[33m",  # yellow
+    logging.ERROR: "\033[31m",  # red
+    logging.CRITICAL: "\033[1;31m",  # bold red
 }
 
 

--- a/backend/app/utils/logger.py
+++ b/backend/app/utils/logger.py
@@ -6,43 +6,61 @@ from typing import Iterable, cast
 
 from app.core.config import settings
 
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_LEVEL_COLORS = {
+    logging.DEBUG: "\033[36m",     # cyan
+    logging.INFO: "\033[32m",      # green
+    logging.WARNING: "\033[33m",   # yellow
+    logging.ERROR: "\033[31m",     # red
+    logging.CRITICAL: "\033[1;31m", # bold red
+}
+
 
 class HealthCheckFilter(logging.Filter):
     def filter(self, record):
         return record.getMessage().find("/health") == -1
 
 
+class ColorFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        copy = logging.makeLogRecord(record.__dict__)
+        color = _LEVEL_COLORS.get(copy.levelno, _RESET)
+        copy.levelname = f"{color}{copy.levelname:<8}{_RESET}"
+        copy.name = f"\033[90m{copy.name:<30}{_RESET}"
+        return super().format(copy)
+
+
+_STREAM_FORMAT = "%(levelname)s | %(name)s | %(message)s"
+_FILE_FORMAT = "%(asctime)s | %(levelname)-8s | %(name)-30s | %(message)s"
+
+
 def setup_logging():
-    # Define logs directory
     BASE_DIR = Path(__file__).resolve().parent.parent.parent
     LOGS_DIR = BASE_DIR / "logs"
     LOGS_DIR.mkdir(exist_ok=True)
     LOG_FILE = LOGS_DIR / "audiovault.log"
 
-    logger = logging.getLogger("uvicorn.access")
-    logger.addFilter(HealthCheckFilter())
+    logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
 
-    # Root logger configuration
-    handlers = [
-        logging.StreamHandler(sys.stdout),
-        TimedRotatingFileHandler(
-            filename=LOG_FILE,
-            when="midnight",
-            interval=1,
-            backupCount=7,
-            encoding="utf-8",
-        ),
-    ]
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(ColorFormatter(_STREAM_FORMAT))
+
+    file_handler = TimedRotatingFileHandler(
+        filename=LOG_FILE,
+        when="midnight",
+        interval=1,
+        backupCount=7,
+        encoding="utf-8",
+    )
+    file_handler.setFormatter(logging.Formatter(_FILE_FORMAT))
 
     logging.basicConfig(
         level=settings.LOG_LEVEL,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        handlers=cast(Iterable[logging.Handler], handlers),
+        handlers=cast(Iterable[logging.Handler], [stream_handler, file_handler]),
         force=True,
     )
 
-    # Silence some noisy libraries
     logging.getLogger("passlib").setLevel(logging.ERROR)
 
-    main_logger = logging.getLogger("app")
-    main_logger.info(f"Logging setup complete. Logs writing to: {LOG_FILE}")
+    logging.getLogger("app").info(f"Logging setup complete. Logs writing to: {LOG_FILE}")


### PR DESCRIPTION
- Remove print(banner) that caused ASCII art to appear twice in Docker logs
- Extract banner as module-level constant, write via sys.stdout to avoid log prefix
- Add separators around banner for visual clarity
- ColorFormatter: DEBUG=cyan, INFO=green, WARNING=yellow, ERROR=red, CRITICAL=bold red
- Stream handler uses format without asctime (Docker already timestamps each line)
- File handler retains full asctime format
- Fix ColorFormatter to copy LogRecord before mutation (avoids corrupting shared record)

## Description

<!-- Describe your changes in detail -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] ♻️ Code refactoring
- [ ] 🔧 Configuration/Dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!-- Link to the issue this PR addresses -->

Closes #

## Testing

<!-- Describe how you tested your changes -->

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] E2E tests updated (if applicable)
- [ ] No new tests needed (explain why)

## Testing Steps

<!-- Provide steps to manually test your changes -->

1.
2.
3.

## Screenshots (if applicable)

<!-- Add screenshots of UI changes -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have added comments only where the WHY is non-obvious (not what the code does)
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] N/A — CHANGELOG.md is auto-generated on release tags

## Breaking Changes

<!-- Describe any breaking changes -->

- None / N/A

## Additional Context

<!-- Add any other context about the PR -->
