### PR TITLE
ci(security): add Socket supply chain scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -224,6 +224,36 @@ jobs:
           path: trivy-secrets.sarif
 
   # ==============================================
+  # Socket.dev Supply Chain Scan (SCA)
+  # ==============================================
+  # Wykrywa malware, typosquat, ryzykowne/maintenance-risk deps w
+  # package-lock.json (root) i pyproject.toml (backend). Uzupełnia Trivy
+  # (znane CVE) o analizę supply chain. Wymaga sekretu SOCKET_CLI_API_TOKEN.
+  socket-scan:
+    name: Socket Supply Chain Scan
+    runs-on: ubuntu-latest
+    # Pomiń gdy brak sekretu (np. fork PR) — nie wywalaj buildu.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install Socket CLI
+        run: npm install -g @socketsecurity/cli
+
+      - name: Run Socket CI scan
+        env:
+          SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_CLI_API_TOKEN }}
+        run: socket ci
+        continue-on-error: true
+
+  # ==============================================
   # License Compliance
   # ==============================================
   license-check:


### PR DESCRIPTION
## Why

`security.yml` ma Trivy (CVE), Semgrep (SAST), secret-scan — ale **brak SCA supply chain**. Trivy łapie znane CVE, nie łapie malware/typosquat/maintenance-risk w deps. Socket wypełnia tę lukę.

## How

Nowy job `socket-scan`:
- `@socketsecurity/cli` + `socket ci` (= `socket scan create --report`, exit≠0 gdy unhealthy)
- `continue-on-error: true` — raport, nie blokada merge (spójne z Trivy/Semgrep)
- `if:` pomija fork PR (brak sekretu → nie wywala buildu)
- skanuje `package-lock.json` (root) + `pyproject.toml` (backend)

## Testing

- YAML zwalidowany (`yaml.safe_load`)
- Sekret `SOCKET_CLI_API_TOKEN` ustawiony w repo Secrets
- Pakiet/env zweryfikowane vs realna binarka (`@socketsecurity/cli`, `SOCKET_CLI_API_TOKEN`)
- Zero wpływu na lokalny dev — Docker/obrazy z registry nietknięte

🤖 Generated with [Claude Code](https://claude.com/claude-code)