### PR TITLE
chore: ignore SQLite db artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ sonar-project.properties
 # Test Artifacts
 backend/coverage_report.txt
 frontend/lint_report.txt
+
+# SQLite databases (test/dev artifacts)
+backend/*.db
 .coverage
 htmlcov/
 coverage/


### PR DESCRIPTION
Add `backend/*.db` to `.gitignore` (catches `test.db`, `audiovault.db`).
Untrack stray 0-byte `backend/audiovault.db` — dev/test artifact, shouldn't be versioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)