### PR TITLE
fix(security): close 51 real CodeQL/SonarCloud alerts; add log sanitizer

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,9 +16,6 @@ on:
     - cron: '0 2 * * 0'
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   # ==============================================
   # Trivy Vulnerability Scanning
@@ -267,6 +264,8 @@ jobs:
   socket-scan:
     name: Socket Supply Chain Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Pomiń gdy brak sekretu (np. fork PR) — nie wywalaj buildu.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
@@ -294,6 +293,8 @@ jobs:
   license-check:
     name: License Compliance
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event_name == 'push' || github.event_name == 'schedule'
 
     steps:

--- a/backend/app/api/subsonic/router.py
+++ b/backend/app/api/subsonic/router.py
@@ -19,6 +19,7 @@ from app.api.subsonic.handlers import (
     system,  # Contains ping, getLicense, getToken
     user,
 )
+from app.utils.log_sanitize import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -62,13 +63,16 @@ router.include_router(info.router)
 @router.api_route("/{path_name:path}", methods=["GET", "POST"])
 def catch_all_subsonic(request: Request, path_name: str):
     """Catch-all for Subsonic to debug 404s."""
-    log_line = f"DEBUG 404: {request.method} /rest/{path_name} | Params: {dict(request.query_params)}\n"
+    safe_method = sanitize_log(request.method)
+    safe_path = sanitize_log(path_name)
+    safe_params = sanitize_log(dict(request.query_params))
+    log_line = f"DEBUG 404: {safe_method} /rest/{safe_path} | Params: {safe_params}\n"
     try:
         with open("/app/subsonic_debug.log", "a") as f:
             f.write(log_line)
     except Exception as e:
         logger.warning("Failed to write subsonic debug log: %s", e)
-    logger.debug(log_line.rstrip())
+    logger.debug("%s", log_line.rstrip())
     return Response(
         content='<?xml version="1.0" encoding="UTF-8"?>\n'
         '<subsonic-response xmlns="http://subsonic.org/restapi" status="failed" version="1.16.1">'

--- a/backend/app/api/v1/downloads.py
+++ b/backend/app/api/v1/downloads.py
@@ -14,6 +14,7 @@ from app.models.download import Download
 from app.models.user import User
 from app.schemas.download import DownloadCreate
 from app.services.download_manager import download_manager
+from app.utils.log_sanitize import sanitize_log
 
 router = APIRouter()
 
@@ -371,7 +372,7 @@ async def download_album(
             raise
         except Exception as e:
             # nosemgrep: python.fastapi.log.tainted-log-injection-stdlib-fastapi.tainted-log-injection-stdlib-fastapi
-            _logger.error(f"Error fetching album {album_id}: {e}")
+            _logger.error("Error fetching album %s: %s", sanitize_log(album_id), sanitize_log(e))
             raise HTTPException(status_code=404, detail="Album not found") from e
         tracks = await service.get_album_tracks(album_id)
     else:

--- a/backend/app/api/v1/import_routes.py
+++ b/backend/app/api/v1/import_routes.py
@@ -8,6 +8,7 @@ from app.core.dependencies import get_current_active_user
 from app.models.user import User
 from app.providers import provider_manager
 from app.schemas.metadata import PlaylistMetadata
+from app.utils.log_sanitize import sanitize_log
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -75,9 +76,7 @@ async def import_playlist(
     using the Universal Provider system.
     Returns the extracted metadata for preview.
     """
-    logger.info(
-        f"Importing playlist from URL: {request.url}"
-    )  # nosemgrep: python.fastapi.log.tainted-log-injection-stdlib-fastapi.tainted-log-injection-stdlib-fastapi
+    logger.info("Importing playlist from URL: %s", sanitize_log(request.url))
 
     try:
         playlist = await provider_manager.extract_playlist(request.url)

--- a/backend/app/api/v1/system.py
+++ b/backend/app/api/v1/system.py
@@ -97,9 +97,9 @@ async def _check_production_update(settings):
                 else:
                     logger.warning(f"Failed to fetch updates from GitHub (Prod): {response.status}")
                     return {"error": "Could not fetch updates"}
-    except Exception as e:
-        logger.error(f"Error checking for updates (Prod): {e}")
-        return {"error": str(e)}
+    except Exception:
+        logger.exception("Error checking for updates (Prod)")
+        return {"error": "Could not fetch updates"}
 
 
 def _get_local_git_sha(git_dir: Path) -> str:
@@ -155,9 +155,9 @@ async def _check_development_update():
                     logger.warning(f"Failed to fetch updates from GitHub (Dev): {response.status}")
                     return {"error": "Could not fetch updates"}
 
-    except Exception as e:
-        logger.error(f"Error checking for updates (Dev): {e}")
-        return {"error": str(e)}
+    except Exception:
+        logger.exception("Error checking for updates (Dev)")
+        return {"error": "Could not fetch updates"}
 
 
 @router.get("/check-update")
@@ -221,5 +221,5 @@ async def get_system_stats():
             "network": {"sent": net_sent, "recv": net_recv},
         }
     except Exception as e:
-        logger.error(f"Error gathering system stats: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to gather system stats: {str(e)}") from e
+        logger.exception("Error gathering system stats")
+        raise HTTPException(status_code=500, detail="Failed to gather system stats") from e

--- a/backend/app/schemas/recommendation.py
+++ b/backend/app/schemas/recommendation.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class RecommendedTrack(BaseModel):
@@ -42,4 +42,4 @@ class RecommendationResponse(BaseModel):
     source: str
     cache_status: str = "miss"
     lastfm_connected: bool = False
-    generated_at: datetime = datetime.now()
+    generated_at: datetime = Field(default_factory=datetime.now)

--- a/backend/app/services/apple_music_service.py
+++ b/backend/app/services/apple_music_service.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 from app.services.base_music_service import BaseMusicService
+from app.utils.log_sanitize import sanitize_log
 
 # Lazy import or direct import if circular dependency is not an issue.
 # Assuming unl_helper is fine.
@@ -24,7 +25,7 @@ class AppleMusicService(BaseMusicService):
             from app.utils.url_helper import resolve_redirects
 
             resolved = await resolve_redirects(url)
-            logger.info(f"Resolved Apple Music short link to: {resolved}")
+            logger.info("Resolved Apple Music short link to: %s", sanitize_log(resolved))
             return resolved
         return url
 

--- a/backend/app/services/base_music_service.py
+++ b/backend/app/services/base_music_service.py
@@ -4,6 +4,8 @@ from typing import Any
 
 import yt_dlp
 
+from app.utils.log_sanitize import sanitize_log
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,7 +37,7 @@ class BaseMusicService:
                 lambda: yt_dlp.YoutubeDL(ydl_opts).extract_info(url, download=False),
             )
         except Exception as e:
-            logger.error(f"Error extracting metadata from {url} using yt-dlp: {e}")
+            logger.error("Error extracting metadata from %s using yt-dlp: %s", sanitize_log(url), sanitize_log(e))
             return None
 
     async def get_tracks(self, url: str) -> list[dict[str, Any]]:

--- a/backend/app/services/deezer_service.py
+++ b/backend/app/services/deezer_service.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import aiohttp
 
+from app.utils.log_sanitize import sanitize_log
+
 logger = logging.getLogger(__name__)
 
 # Deezer enforces ~50 requests / 5s. A recommendation refresh fires dozens of
@@ -59,13 +61,19 @@ class DeezerService:
 
             error = data.get("error") if isinstance(data, dict) else None
             if error and error.get("code") == DEEZER_QUOTA_ERROR_CODE:
-                logger.warning(f"Deezer quota exceeded for {path}, retry {attempt + 1}/{retries} in {backoff}s")
+                logger.warning(
+                    "Deezer quota exceeded for %s, retry %d/%d in %ss",
+                    sanitize_log(path),
+                    attempt + 1,
+                    retries,
+                    backoff,
+                )
                 await asyncio.sleep(backoff)
                 backoff *= 2
                 continue
             return data
 
-        logger.error(f"Deezer quota still exceeded after {retries} attempts for {path}")
+        logger.error("Deezer quota still exceeded after %d attempts for %s", retries, sanitize_log(path))
         return None
 
     async def _maybe_resolve_short_link(self, query: str) -> str:
@@ -74,7 +82,7 @@ class DeezerService:
 
             resolved = await resolve_redirects(query)
             if resolved != query:
-                logger.info(f"Resolved Deezer short link to: {resolved}")
+                logger.info("Resolved Deezer short link to: %s", sanitize_log(resolved))
                 return resolved
         return query
 
@@ -97,7 +105,7 @@ class DeezerService:
         )
         if url_match:
             kind, deezer_id = url_match.groups()
-            logger.info(f"Detected Deezer URL: kind={kind}, id={deezer_id}")
+            logger.info("Detected Deezer URL: kind=%s, id=%s", sanitize_log(kind), sanitize_log(deezer_id))
             result = await self._handle_direct_url(kind, deezer_id)
             if result is not None:
                 return result

--- a/backend/app/services/download_manager.py
+++ b/backend/app/services/download_manager.py
@@ -21,6 +21,7 @@ from app.models.track import Track
 from app.schemas.download import DownloadCreate
 from app.services.fallback_service import fallback_service
 from app.services.socket_manager import socket_manager
+from app.utils.log_sanitize import sanitize_log
 from app.utils.sanitization import sanitize_filename
 
 logger = logging.getLogger(__name__)
@@ -166,7 +167,7 @@ class DownloadManager:
         self.paused_downloads.add(download_id)
         # If it's currently running, we can't easily stop yt-dlp except via the hook exception
         # The hook will raise exception and process_download will catch it and update DB
-        logger.info(f"Requested pause for {download_id}")
+        logger.info("Requested pause for %s", sanitize_log(download_id))
 
     async def resume_pending_downloads(self, db: AsyncSession):
         """Resume downloads that were pending or interrupted during restart."""
@@ -584,7 +585,7 @@ class DownloadManager:
             await db.commit()
             await self.queue.put(download.id)
             await self.start_worker()
-            logger.info(f"Resumed download {download_id}")
+            logger.info("Resumed download %s", sanitize_log(download_id))
 
     async def cancel_download(self, db: AsyncSession, download_id: str):
         # Remove from pause list if there
@@ -606,7 +607,7 @@ class DownloadManager:
         if download:
             await db.delete(download)
             await db.commit()
-            logger.info(f"Cancelled and deleted download {download_id}")
+            logger.info("Cancelled and deleted download %s", sanitize_log(download_id))
 
             await socket_manager.emit("download:cancelled", {"download_id": download_id})
 
@@ -874,7 +875,9 @@ class DownloadManager:
             downloads = await self._get_playlist_downloads(db, user_id, source, playlist_name)
 
             if not downloads:
-                logger.info(f"No downloads found for playlist {playlist_name} ({source})")
+                logger.info(
+                    "No downloads found for playlist %s (%s)", sanitize_log(playlist_name), sanitize_log(source)
+                )
                 return
 
             self._delete_physical_files(downloads)
@@ -894,10 +897,14 @@ class DownloadManager:
                 await db.execute(delete(PlaylistTrack).where(PlaylistTrack.playlist_id == playlist_obj.id))
                 await db.execute(delete(Playlist).where(Playlist.id == playlist_obj.id))
 
-            logger.info(f"Deleted playlist {playlist_name} for user {user_id} and synced with playlists/tracks tables")
+            logger.info(
+                "Deleted playlist %s for user %s and synced with playlists/tracks tables",
+                sanitize_log(playlist_name),
+                sanitize_log(user_id),
+            )
 
         except Exception as e:
-            logger.error(f"Error deleting playlist {playlist_name}: {e}")
+            logger.error("Error deleting playlist %s: %s", sanitize_log(playlist_name), sanitize_log(e))
             raise e
 
     async def _get_playlist_downloads(self, db: AsyncSession, user_id, source, playlist_name):

--- a/backend/app/services/library_scanner.py
+++ b/backend/app/services/library_scanner.py
@@ -15,6 +15,7 @@ from app.models.album import Album
 from app.models.artist import Artist
 from app.models.download import Download
 from app.models.track import Track
+from app.utils.log_sanitize import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -188,7 +189,9 @@ class LibraryScannerService:
                 else:
                     playlist_name = parts[0]
         except Exception as e:
-            logger.debug(f"Failed to infer source info for {full_path}: {e}")  # Fallback to default
+            logger.debug(
+                "Failed to infer source info for %s: %s", sanitize_log(full_path), sanitize_log(e)
+            )  # Fallback to default
 
         return source, playlist_name
 
@@ -248,7 +251,7 @@ class LibraryScannerService:
                 playlist = Playlist(name=name, owner_id=user_id)
                 db.add(playlist)
                 await db.flush()
-                logger.info(f"Created new playlist from file: {name}")
+                logger.info("Created new playlist from file: %s", sanitize_log(name))
 
             # Parse file and collect matched tracks FIRST
             base_dir = os.path.dirname(full_path)
@@ -279,12 +282,12 @@ class LibraryScannerService:
                     db.add(pt)
 
                 await db.commit()
-                logger.info(f"Imported playlist {name} with {len(matched_tracks)} tracks")
+                logger.info("Imported playlist %s with %d tracks", sanitize_log(name), len(matched_tracks))
             else:
-                logger.info(f"Playlist {name}: No tracks matched, keeping existing data")
+                logger.info("Playlist %s: No tracks matched, keeping existing data", sanitize_log(name))
 
         except Exception as e:
-            logger.error(f"Failed to import playlist {full_path}: {e}")
+            logger.error("Failed to import playlist %s: %s", sanitize_log(full_path), sanitize_log(e))
 
     async def _find_track_for_playlist_line(self, db: AsyncSession, line: str, base_dir: str, user_id: str):
         # Resolve track path with path traversal protection
@@ -409,7 +412,7 @@ class LibraryScannerService:
             return True
 
         except Exception as e:
-            logger.error(f"Failed to import {filename}: {str(e)}")
+            logger.error("Failed to import %s: %s", sanitize_log(filename), sanitize_log(e))
             raise e
 
     async def _handle_scan_file(self, db, user_id, full_path, filename, root_dir, known_paths) -> bool:

--- a/backend/app/services/lyrics_service.py
+++ b/backend/app/services/lyrics_service.py
@@ -8,6 +8,7 @@ import logging
 
 from app.core.cache import cache_manager
 from app.core.config import settings
+from app.utils.log_sanitize import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -145,11 +146,21 @@ class LyricsService:
                         "source": "lrclib",
                     }
                 elif response.status_code == 404:
-                    logger.info(f"LRCLIB: No lyrics found for {artist} - {title}")
+                    logger.info("LRCLIB: No lyrics found for %s - %s", sanitize_log(artist), sanitize_log(title))
                 else:
-                    logger.warning(f"LRCLIB: API error {response.status_code} for {artist} - {title}")
+                    logger.warning(
+                        "LRCLIB: API error %s for %s - %s",
+                        response.status_code,
+                        sanitize_log(artist),
+                        sanitize_log(title),
+                    )
         except Exception as e:
-            logger.error(f"LRCLIB: Request failed for {artist} - {title}: {e}")
+            logger.error(
+                "LRCLIB: Request failed for %s - %s: %s",
+                sanitize_log(artist),
+                sanitize_log(title),
+                sanitize_log(e),
+            )
 
         return {"found": False, "lyrics": None, "synced_lyrics": None}
 
@@ -159,7 +170,7 @@ class LyricsService:
             cached_str = await cache_manager.get(cache_key)
             if cached_str:
                 cached = json.loads(cached_str)
-                logger.debug(f"Lyrics cache hit for {artist} - {title}")
+                logger.debug("Lyrics cache hit for %s - %s", sanitize_log(artist), sanitize_log(title))
                 return cached
         except Exception as e:
             logger.warning(f"Cache read error: {e}")
@@ -171,7 +182,7 @@ class LyricsService:
             song = genius.search_song(title, artist)
 
             if not song:
-                logger.info(f"No lyrics found for {artist} - {title}")
+                logger.info("No lyrics found for %s - %s", sanitize_log(artist), sanitize_log(title))
                 # Cache negative result for shorter time (1 hour)
                 await self._cache_result(cache_key, {"found": False, "lyrics": None}, 3600)
                 return {"found": False, "lyrics": None}
@@ -188,12 +199,17 @@ class LyricsService:
 
             # Cache successful result
             await self._cache_result(cache_key, result, LYRICS_CACHE_TTL)
-            logger.debug(f"Cached lyrics for {artist} - {title}")
+            logger.debug("Cached lyrics for %s - %s", sanitize_log(artist), sanitize_log(title))
 
             return result
 
         except Exception as e:
-            logger.error(f"Failed to fetch lyrics for {artist} - {title}: {e}")
+            logger.error(
+                "Failed to fetch lyrics for %s - %s: %s",
+                sanitize_log(artist),
+                sanitize_log(title),
+                sanitize_log(e),
+            )
             return None
 
     async def _cache_result(self, key: str, data: dict, ttl: int):

--- a/backend/app/services/scrobbler.py
+++ b/backend/app/services/scrobbler.py
@@ -3,6 +3,7 @@ import time
 
 from app.models.user import User
 from app.services.lastfm_service import LastfmError, LastfmService
+from app.utils.log_sanitize import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,12 @@ class AudiovaultScrobbler:
                 session_key=user.lastfm_session_key,
                 album=album,
             )
-            logger.debug(f"Updated Now Playing for {user.username}: {artist_to_scrobble} - {track}")
+            logger.debug(
+                "Updated Now Playing for %s: %s - %s",
+                sanitize_log(user.username),
+                sanitize_log(artist_to_scrobble),
+                sanitize_log(track),
+            )
         except LastfmError as e:
             logger.error(f"Failed to update now playing for {user.username}: {e}")
 
@@ -51,7 +57,12 @@ class AudiovaultScrobbler:
                 timestamp=timestamp or int(time.time()),
                 album=album,
             )
-            logger.info(f"Scrobbled for {user.username}: {artist_to_scrobble} - {track}")
+            logger.info(
+                "Scrobbled for %s: %s - %s",
+                sanitize_log(user.username),
+                sanitize_log(artist_to_scrobble),
+                sanitize_log(track),
+            )
             return True
         except LastfmError as e:
             logger.error(f"Failed to scrobble for {user.username}: {e}")

--- a/backend/app/services/soundcloud_service.py
+++ b/backend/app/services/soundcloud_service.py
@@ -5,6 +5,8 @@ from urllib.parse import urlparse
 
 import yt_dlp
 
+from app.utils.log_sanitize import sanitize_log
+
 logger = logging.getLogger(__name__)
 
 _SOUNDCLOUD_HOSTS = {"soundcloud.com", "www.soundcloud.com", "on.soundcloud.com", "m.soundcloud.com"}
@@ -41,13 +43,13 @@ class SoundCloudService:
         }
 
         try:
-            logger.info(f"Extracting SoundCloud metadata from: {url}")
+            logger.info("Extracting SoundCloud metadata from: %s", sanitize_log(url))
 
             if "on.soundcloud.com" in url:
                 from app.utils.url_helper import resolve_redirects
 
                 url = await resolve_redirects(url)
-                logger.info(f"Resolved SoundCloud short link to: {url}")
+                logger.info("Resolved SoundCloud short link to: %s", sanitize_log(url))
 
             loop = asyncio.get_running_loop()
             info = await loop.run_in_executor(

--- a/backend/app/services/spotify_service.py
+++ b/backend/app/services/spotify_service.py
@@ -34,6 +34,7 @@ import httpx
 
 from app.core.config import settings
 from app.services.spotify_partner import partner_client  # noqa: E402
+from app.utils.log_sanitize import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -366,7 +367,7 @@ class SpotifyService:
                 resp.raise_for_status()
                 return resp.json()
             except Exception as e:
-                logger.error(f"Spotify API [{endpoint}]: {e}")
+                logger.error("Spotify API [%s]: %s", sanitize_log(endpoint), sanitize_log(e))
                 return None
 
     # ------------------------------------------------------------------ #
@@ -409,7 +410,7 @@ class SpotifyService:
                 resp.raise_for_status()
                 return resp.json()
             except Exception as e:
-                logger.debug(f"Host proxy unavailable ({url}): {e}")
+                logger.debug("Host proxy unavailable (%s): %s", sanitize_log(url), sanitize_log(e))
                 return None
 
     # ------------------------------------------------------------------ #

--- a/backend/app/services/youtube_service.py
+++ b/backend/app/services/youtube_service.py
@@ -5,6 +5,7 @@ from typing import Any
 from ytmusicapi import YTMusic
 
 from app.services.base_music_service import BaseMusicService
+from app.utils.log_sanitize import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ class YouTubeService(BaseMusicService):
         self.source_name = "youtube"
 
     def search(self, query: str, limit: int = 20, type: str = "song") -> list[dict[str, Any]]:
-        logger.info(f"YouTube search query: {query}, type: {type}")
+        logger.info("YouTube search query: %s, type: %s", sanitize_log(query), sanitize_log(type))
 
         video_match = re.search(
             r"(?:youtube\.com/(?:watch\?v=|shorts/)|youtu\.be/|music\.youtube\.com/watch\?v=)([a-zA-Z0-9_-]+)",
@@ -67,7 +68,7 @@ class YouTubeService(BaseMusicService):
             if results:
                 return [self._format_track(results[0])]
         except Exception as e:
-            logger.warning(f"Error fetching video details for {video_id}: {e}")
+            logger.warning("Error fetching video details for %s: %s", sanitize_log(video_id), sanitize_log(e))
             return []
         return []
 
@@ -86,7 +87,7 @@ class YouTubeService(BaseMusicService):
                 }
             ]
         except Exception as e:
-            logger.error(f"Error fetching YouTube playlist {playlist_id}: {e}")
+            logger.error("Error fetching YouTube playlist %s: %s", sanitize_log(playlist_id), sanitize_log(e))
         return []
 
     def _search_channel(self, channel_id: str) -> list[dict[str, Any]]:
@@ -104,7 +105,7 @@ class YouTubeService(BaseMusicService):
                     }
                 ]
         except Exception as e:
-            logger.warning(f"Error fetching channel details {channel_id}: {e}")
+            logger.warning("Error fetching channel details %s: %s", sanitize_log(channel_id), sanitize_log(e))
         return []
 
     def _search_keywords(self, query: str, limit: int, type: str) -> list[dict[str, Any]]:
@@ -196,7 +197,7 @@ class YouTubeService(BaseMusicService):
                 "tracks": tracks,
             }
         except Exception as e:
-            logger.error(f"Error fetching YouTube playlist details {playlist_id}: {e}")
+            logger.error("Error fetching YouTube playlist details %s: %s", sanitize_log(playlist_id), sanitize_log(e))
             return None
 
     def _format_track(self, item: dict[str, Any], album_name=None) -> dict[str, Any]:

--- a/backend/app/utils/log_sanitize.py
+++ b/backend/app/utils/log_sanitize.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+_MAX_LOG_LEN = 200
+
+
+def sanitize_log(value: Any, max_len: int = _MAX_LOG_LEN) -> str:
+    """Strip CR/LF/TAB and other control chars from values flowing into log records.
+
+    Use on any user-controlled value before interpolating into a log message — prevents
+    log forging (CWE-117) where attacker-supplied newlines split or spoof log lines.
+    """
+    s = str(value)
+    s = s.replace("\r", "").replace("\n", " ").replace("\t", " ")
+    s = "".join(ch for ch in s if ch >= " " or ch == " ")
+    if len(s) > max_len:
+        s = s[: max_len - 3] + "..."
+    return s

--- a/backend/app/utils/url_helper.py
+++ b/backend/app/utils/url_helper.py
@@ -5,6 +5,8 @@ from urllib.parse import urlparse
 
 import aiohttp
 
+from app.utils.log_sanitize import sanitize_log
+
 logger = logging.getLogger(__name__)
 
 # Allowed domains for music services
@@ -131,7 +133,7 @@ async def resolve_redirects(url: str) -> str:
     # Validate initial URL
     is_valid, error = validate_url(url)
     if not is_valid:
-        logger.warning(f"SSRF validation failed for {url}: {error}")
+        logger.warning("SSRF validation failed for %s: %s", sanitize_log(url), sanitize_log(error))
         raise SSRFValidationError(error)
 
     try:
@@ -143,14 +145,18 @@ async def resolve_redirects(url: str) -> str:
                 # Validate final URL too (in case of open redirect)
                 is_valid, error = validate_url(final_url)
                 if not is_valid:
-                    logger.warning(f"SSRF validation failed for redirect {final_url}: {error}")
+                    logger.warning(
+                        "SSRF validation failed for redirect %s: %s",
+                        sanitize_log(final_url),
+                        sanitize_log(error),
+                    )
                     raise SSRFValidationError(f"Redirect blocked: {error}")
 
                 return final_url
     except SSRFValidationError:
         raise
     except Exception as e:
-        logger.warning(f"Failed to resolve URL {url}: {e}")
+        logger.warning("Failed to resolve URL %s: %s", sanitize_log(url), sanitize_log(e))
         # If head fails (e.g. 405 Method Not Allowed), try GET
         try:
             async with aiohttp.ClientSession() as session:
@@ -166,5 +172,5 @@ async def resolve_redirects(url: str) -> str:
         except SSRFValidationError:
             raise
         except Exception as e2:
-            logger.error(f"Failed to resolve URL {url} with GET: {e2}")
+            logger.error("Failed to resolve URL %s with GET: %s", sanitize_log(url), sanitize_log(e2))
             return url

--- a/frontend/nginx-main.conf
+++ b/frontend/nginx-main.conf
@@ -16,6 +16,18 @@ http {
 
     access_log  /var/log/nginx/access.log  main;
 
+    # H2C smuggling defense: only websocket Upgrade is forwarded; all other
+    # Upgrade values get an empty Connection header so they cannot tunnel
+    # plaintext HTTP/2 past the proxy access controls.
+    map $http_upgrade $connection_upgrade {
+        default     "";
+        websocket   "upgrade";
+    }
+    map $http_upgrade $safe_upgrade {
+        default     "";
+        websocket   "websocket";
+    }
+
     sendfile        on;
     #tcp_nopush     on;
     keepalive_timeout  65;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -42,9 +42,12 @@ server {
 
     location /socket.io {
         proxy_pass http://backend:8000;
+        # H2C smuggling defense: $safe_upgrade and $connection_upgrade are mapped
+        # in nginx-main.conf to forward ONLY Upgrade: websocket; all other Upgrade
+        # values resolve to "" and prevent h2c tunneling. Rule cannot follow the map.
         proxy_http_version 1.1; # nosemgrep: generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Upgrade $safe_upgrade; # nosemgrep: generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
+        proxy_set_header Connection $connection_upgrade; # nosemgrep: generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- Address 51 real findings (CodeQL + SonarCloud + Semgrep) from the 129-alert backlog. 78 false positives dismissed via API in a parallel pass.

## Real fixes
| # | Severity | Where | Rule | Change |
|---|---|---|---|---|
| 1 | **High** | `backend/app/schemas/recommendation.py:45` | SonarCloud `pythonenterprise:S8434` | `datetime = datetime.now()` -> `Field(default_factory=datetime.now)` (Pydantic class-body eval bug) |
| 2 | **Medium** | `backend/app/api/v1/system.py:102,160,225` | CodeQL `py/stack-trace-exposure` | replace `return {"error": str(e)}` / HTTPException details with generic text + `logger.exception(...)` |
| 3 | **Medium** | 42x backend (services + api) + 2x SonarCloud dups | CodeQL `py/log-injection`, SonarCloud `pythonsecurity:S5145` | new `backend/app/utils/log_sanitize.py` `sanitize_log()` strips CR/LF/TAB and truncates; applied at every flagged call site via `%s` parameterized logging |
| 4 | **Low** | `frontend/nginx.conf:43-52` + `frontend/nginx-main.conf` | Semgrep `nginx-h2c-smuggling` | add `$safe_upgrade` / `$connection_upgrade` maps in http{} so only `Upgrade: websocket` is forwarded |
| 5 | **Low** | `.github/workflows/security.yml` | SonarCloud `githubactions:S8264` | drop workflow-level `permissions: contents: read`; add explicit per-job blocks to `socket-scan` + `license-check` |

## False positives (78) — already dismissed via API
- `python:S1313` x23 (RFC1918 CIDR constants + SSRF unit tests) — `false positive` / `used in tests`
- `python:S2068` x14 (test fixture passwords) — `used in tests`
- `python-print-statement` x15 (`tests/run_all.py`, `coverage_analyzer.py`) — `won't fix`
- `py/log-injection` x6 in standalone `spotify-host-proxy.py` (single-user CLI) — `won't fix`
- `md5-used-as-password` x2 (Subsonic spec mandate + bcrypt-backed sync) — `won't fix`
- `path-traversal` x4 (already mitigated by `pathlib.Path.is_relative_to` in commits a3551d4/b21a7f7) — `false positive`
- `py/partial-ssrf` + `pythonsecurity:S7044` (admin-env base + regex-validated id + type allowlist) — `false positive`
- `console-log-production`, SRI on local Vite bundle, Django-regex misfire on non-Django code, etc. (see dismiss script comments)

## Test plan
- [x] `ruff check backend/app/` — All checks passed
- [x] `docker compose exec backend pytest tests/` — 1120 passed, 2 skipped
- [x] pre-commit hooks: ggshield, ruff, semgrep — Passed
- [x] pre-push CI checks — Passed (coverage 81.19%)
- [ ] Verify CodeQL re-run on `dev` after merge: expected ~0 new alerts in modified files