### PR TITLE
Merge dev → main: CI fixes (fastapi 0.136.3 mypy + rate limiter test bypass)

### DIFF
--- a/backend/app/services/recommendation_engine.py
+++ b/backend/app/services/recommendation_engine.py
@@ -9,6 +9,7 @@ from app.models.user import User
 from app.schemas.recommendation import RecommendationResponse, RecommendedArtist, RecommendedPlaylist, RecommendedTrack
 from app.services.deezer_service import DeezerService
 from app.services.lastfm_service import LastfmError, LastfmService
+from app.utils.log_sanitize import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,11 @@ class HybridRecommendationEngine:
         try:
             target_user = user.lastfm_username or user.username
             session_key = user.lastfm_session_key
-            logger.info(f"Fetching recommendations from Last.fm for user {target_user} (variety={variety})")
+            logger.info(
+                "Fetching recommendations from Last.fm for user %s (variety=%s)",
+                sanitize_log(target_user),
+                variety,
+            )
             tracks = await self.lastfm.get_recommendations(target_user, session_key=session_key, variety=variety)
 
             # --- Spotify Image Fallback ---

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -138,8 +138,9 @@ async def client(
     for route in app.routes:
         from fastapi.routing import APIRoute
 
-        if isinstance(route, APIRoute) and route.dependencies:
-            for d in route.dependencies:
+        route_dependencies = getattr(route, "dependencies", None)
+        if isinstance(route, APIRoute) and route_dependencies:
+            for d in route_dependencies:
                 if d.dependency and type(d.dependency).__name__ == "RateLimiter":
                     app.dependency_overrides[d.dependency] = bypass_limiter
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -135,14 +135,13 @@ async def client(
     async def bypass_limiter():
         return
 
-    for route in app.routes:
-        from fastapi.routing import APIRoute
+    # Rate limiters are module-level singletons used as Depends(...) markers.
+    # Override them directly instead of scanning app.routes — FastAPI's routing
+    # internals (APIRoute.dependencies, _IncludedRouter) shift between versions.
+    from app.api.v1.auth import login_limiter, register_limiter
 
-        route_dependencies = getattr(route, "dependencies", None)
-        if isinstance(route, APIRoute) and route_dependencies:
-            for d in route_dependencies:
-                if d.dependency and type(d.dependency).__name__ == "RateLimiter":
-                    app.dependency_overrides[d.dependency] = bypass_limiter
+    for limiter in (login_limiter, register_limiter):
+        app.dependency_overrides[limiter] = bypass_limiter
 
     # Mock download_dir to use a temp dir
     import tempfile


### PR DESCRIPTION
## Co

Wrzucenie poprawek z `dev` na `main`. Wszystkie 3 commity:

- `fix(security)` — sanitize user-controlled log input w recommendation engine
- `fix(ci)` — APIRoute.dependencies mypy fix (zastąpione przez poniższe)
- `fix(tests)` — override rate limiter singletonów zamiast skanowania route'ów; naprawia testy auth/registration po bumpie fastapi 0.136.3 (`_IncludedRouter` routing change)

## Weryfikacja

- Dev CI zielony (Multi-Platform CI: lint+mypy, pytest, frontend)
- mypy `267 source files` clean
- 14 testów auth/registration pass lokalnie

🤖 Generated with [Claude Code](https://claude.com/claude-code)